### PR TITLE
Patch single user prevent duplicates

### DIFF
--- a/__tests__/users.tests.js
+++ b/__tests__/users.tests.js
@@ -80,6 +80,28 @@ describe("/api/users/:username", () => {
         expect(body.msg).toBe("Bad Request");
       });
   });
+  test("PATCH: 400 responds with Bad Request when username is taken", () => {
+    const badRequest = { username: "George" };
+
+    return request(app)
+      .patch("/api/users/Janet")
+      .expect(400)
+      .send(badRequest)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad Request: Username/email exists in table");
+      });
+  });
+  test("PATCH: 400 responds with Bad Request when email is taken", () => {
+    const badRequest = { email: "george.bluth@reqres.in" };
+
+    return request(app)
+      .patch("/api/users/Janet")
+      .expect(400)
+      .send(badRequest)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad Request: Username/email exists in table");
+      });
+  });
 });
 
 describe("/api/users/", () => {

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -52,8 +52,8 @@ function seed({
       return db.query(`
             CREATE TABLE users (
             user_id SERIAL PRIMARY KEY,
-            username VARCHAR (20) NOT NULL,
-            email VARCHAR(50) NOT NULL,
+            username VARCHAR (20) NOT NULL UNIQUE,
+            email VARCHAR(50) NOT NULL UNIQUE,
             password VARCHAR(60),
             avatar_id INT REFERENCES avatars(avatar_id),
             is_child BOOLEAN,

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -1,5 +1,4 @@
 const db = require("../db/connection");
-const format = require("pg-format");
 const bcrypt = require("bcrypt");
 const { checkIfExists } = require("./users.utils");
 

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -94,7 +94,7 @@ exports.modifyUser = (modifiedUser, username) => {
         SET ${setColumnStatemnts.join(",")}
         WHERE user_id = $1;
         `;
-      return db.query(queryStr, [ user_id]);
+      return db.query(queryStr, [ user_id]).catch((err) => {return Promise.reject({status: 400, msg: "Bad Request: Username/email exists in table"})});
     })
     .then(() => {
       return db.query(


### PR DESCRIPTION
Added error handling to patch request on users/:username endpoint, to prevent duplicate usernames/email being patched